### PR TITLE
feat: switch from nvm to volta for Node.js version management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,24 +8,63 @@ This is an Amazon ebook scraper project that appears to be in the initial setup 
 
 ## Current State
 
-The repository is currently empty with only:
-- Empty README.md
-- Standard Node.js .gitignore
-- Git repository initialized
+The repository is configured as a pnpm monorepo with:
+- Root package.json with workspace configuration
+- pnpm-workspace.yaml defining workspace structure
+- TypeScript configuration for monorepo development
+- Initial packages structure (packages/, apps/, libs/, tools/)
+- Sample scraper package in packages/scraper
 
 ## Development Setup
 
-Since this is a new project, typical Node.js development commands will likely be:
-- `npm init` - Initialize package.json
-- `npm install` - Install dependencies
-- `npm run dev` - Development server (once configured)
-- `npm test` - Run tests (once configured)
-- `npm run build` - Build for production (once configured)
+This project uses pnpm as the package manager in a monorepo configuration. Common commands:
+
+### Project Setup
+- `pnpm install` - Install all dependencies for all workspaces
+- `pnpm install:all` - Alias for pnpm install
+
+### Development Commands
+- `pnpm dev` - Start development servers for all packages
+- `pnpm build` - Build all packages
+- `pnpm test` - Run tests for all packages
+- `pnpm lint` - Lint all packages
+- `pnpm clean` - Clean build artifacts from all packages
+
+### Workspace-specific Commands
+- `pnpm -F <package-name> <command>` - Run command in specific package
+- `pnpm -F @amazon-ebook-scraper/scraper dev` - Run dev server for scraper package
+
+### Adding Dependencies
+- `pnpm add <package>` - Add dependency to root
+- `pnpm -F <workspace> add <package>` - Add dependency to specific workspace
+
+### Package Manager Requirements
+- Node.js 18.20.4 (managed by volta)
+- pnpm 9.0.0 (managed by volta)
+
+### Node.js Version Management
+This project uses [volta](https://volta.sh/) for Node.js and pnpm version management. The versions are specified in the `volta` field in package.json:
+- Install volta: `curl https://get.volta.sh | bash`
+- After installing volta, the correct Node.js and pnpm versions will be automatically used when you cd into this directory
+- Manual installation: `volta install node@18.20.4 pnpm@9.0.0`
+
+## Monorepo Structure
+
+The project follows a monorepo structure with the following directories:
+
+- `packages/` - Core application packages and libraries
+- `apps/` - Standalone applications (web apps, CLIs, etc.)
+- `libs/` - Shared libraries and utilities
+- `tools/` - Development tools and scripts
+
+### Current Packages
+
+- `@amazon-ebook-scraper/scraper` - Core scraping functionality (packages/scraper)
 
 ## Notes
 
-This project is in the initial setup phase. Future updates to this file should include:
-- Package manager commands once package.json is created
-- Testing framework commands once tests are set up
-- Build and deployment processes once configured
-- Architecture details once the codebase is developed
+The project has been set up with pnpm monorepo configuration. Future development should:
+- Add new packages to appropriate directories (packages/, apps/, libs/, tools/)
+- Use workspace references for inter-package dependencies
+- Follow the established TypeScript configuration
+- Maintain consistent naming convention with @amazon-ebook-scraper/ scope

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "amazon-ebook-scraper",
+  "version": "1.0.0",
+  "description": "Amazon ebook scraper project",
+  "author": "homura10059",
+  "license": "MIT",
+  "private": true,
+  "packageManager": "pnpm@9.0.0",
+  "volta": {
+    "node": "18.20.4",
+    "pnpm": "9.0.0"
+  },
+  "scripts": {
+    "dev": "pnpm -r run dev",
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "lint": "pnpm -r run lint",
+    "clean": "pnpm -r run clean",
+    "install:all": "pnpm install",
+    "update:all": "pnpm update"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "pnpm": ">=8.0.0"
+  },
+  "keywords": [
+    "amazon",
+    "ebook",
+    "scraper",
+    "monorepo",
+    "pnpm"
+  ]
+}


### PR DESCRIPTION
Implements request to switch from nvm to volta for Node.js version management

## Changes
- Remove .nvmrc file
- Add volta configuration to package.json with Node.js 18.20.4 and pnpm 9.0.0
- Update CLAUDE.md with volta usage instructions and requirements

## Benefits
- Automatic version switching when entering project directory
- Consistent Node.js and pnpm versions across development environments
- Better integration with monorepo setup

Generated with [Claude Code](https://claude.ai/code)