### PR TITLE
feat: introduce Biome code formatter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ The repository is configured as a pnpm monorepo with:
 - Root package.json with workspace configuration
 - pnpm-workspace.yaml defining workspace structure
 - TypeScript configuration for monorepo development
+- Biome code formatter and linter configured (biome.json)
 - Initial packages structure (packages/, apps/, libs/, tools/)
 - Sample scraper package in packages/scraper
 
@@ -29,6 +30,21 @@ This project uses pnpm as the package manager in a monorepo configuration. Commo
 - `pnpm test` - Run tests for all packages
 - `pnpm lint` - Lint all packages
 - `pnpm clean` - Clean build artifacts from all packages
+
+### Code Formatting and Linting
+This project uses [Biome](https://biomejs.dev/) for code formatting and linting:
+
+- `pnpm format` - Format all files using Biome
+- `pnpm format:check` - Check if files are formatted correctly (no changes)
+- `pnpm lint:biome` - Lint files using Biome
+- `pnpm check` - Run both formatting and linting checks
+- `pnpm check:fix` - Run checks and apply automatic fixes
+
+#### Biome Configuration
+- Configuration is stored in `biome.json` at the project root
+- Uses default Biome settings with 2-space indentation
+- Configured to ignore node_modules, dist, and build directories
+- Integrates with Git for tracking changes
 
 ### Workspace-specific Commands
 - `pnpm -F <package-name> <command>` - Run command in specific package
@@ -68,3 +84,5 @@ The project has been set up with pnpm monorepo configuration. Future development
 - Use workspace references for inter-package dependencies
 - Follow the established TypeScript configuration
 - Maintain consistent naming convention with @amazon-ebook-scraper/ scope
+- Run `pnpm format` before committing to ensure consistent code formatting
+- Use `pnpm check` to verify code formatting and linting before commits

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["**/node_modules/**", "**/dist/**", "**/build/**"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "es5",
+      "semicolons": "always"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "build": "pnpm -r run build",
     "test": "pnpm -r run test",
     "lint": "pnpm -r run lint",
+    "lint:biome": "biome lint .",
+    "format": "biome format --write .",
+    "format:check": "biome format .",
+    "check": "biome check .",
+    "check:fix": "biome check --fix .",
     "clean": "pnpm -r run clean",
     "install:all": "pnpm install",
     "update:all": "pnpm update"
@@ -23,11 +28,8 @@
     "node": ">=18.0.0",
     "pnpm": ">=8.0.0"
   },
-  "keywords": [
-    "amazon",
-    "ebook",
-    "scraper",
-    "monorepo",
-    "pnpm"
-  ]
+  "keywords": ["amazon", "ebook", "scraper", "monorepo", "pnpm"],
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4"
+  }
 }

--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -22,9 +22,5 @@
     "vitest": "^1.0.0",
     "eslint": "^8.0.0"
   },
-  "keywords": [
-    "scraper",
-    "amazon",
-    "ebook"
-  ]
+  "keywords": ["scraper", "amazon", "ebook"]
 }

--- a/packages/scraper/tsconfig.json
+++ b/packages/scraper/tsconfig.json
@@ -6,13 +6,6 @@
     "composite": true,
     "noEmit": false
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "**/*.test.ts",
-    "**/*.spec.ts"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,16 +21,11 @@
   },
   "include": [
     "packages/*/src/**/*",
-    "apps/*/src/**/*", 
+    "apps/*/src/**/*",
     "libs/*/src/**/*",
     "tools/*/src/**/*"
   ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "**/*.test.ts",
-    "**/*.spec.ts"
-  ],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"],
   "references": [
     {
       "path": "./packages/scraper"


### PR DESCRIPTION
Resolves #4

This PR introduces Biome code formatter and linter to the project with default configuration.

## Changes
- Add @biomejs/biome as dev dependency
- Create biome.json with default settings
- Add Biome scripts to package.json
- Update CLAUDE.md with usage instructions
- Format existing files using Biome

## Available Commands
- `pnpm format` - Format all files
- `pnpm format:check` - Check formatting
- `pnpm lint:biome` - Lint with Biome
- `pnpm check` - Combined check
- `pnpm check:fix` - Apply fixes

Generated with [Claude Code](https://claude.ai/code)