### PR TITLE
feat: update Node.js to latest LTS v22.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "packageManager": "pnpm@9.0.0",
   "volta": {
-    "node": "18.20.4",
+    "node": "22.16.0",
     "pnpm": "9.0.0"
   },
   "scripts": {
@@ -25,7 +25,7 @@
     "update:all": "pnpm update"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=22.0.0",
     "pnpm": ">=8.0.0"
   },
   "keywords": ["amazon", "ebook", "scraper", "monorepo", "pnpm"],

--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -15,7 +15,7 @@
     "cheerio": "^1.0.0-rc.12"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "tsx": "^4.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0",


### PR DESCRIPTION
Update Node.js from 18.20.4 to latest LTS v22.16.0

## Changes
- Updated volta configuration to use Node.js 22.16.0
- Updated engines requirement to >=22.0.0
- Updated @types/node to ^22.0.0 in scraper package
- Maintained pnpm 9.0.0 compatibility

Generated with [Claude Code](https://claude.ai/code)