### PR TITLE
feat: introduce lefthook for shared git hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,29 +58,38 @@ This project uses [Biome](https://biomejs.dev/) for code formatting and linting:
 #### ESLint Prohibition
 **IMPORTANT**: ESLint is prohibited in this project. All packages must use Biome for linting and formatting. Do not add ESLint dependencies or configuration to any package.json files. Use `biome check` commands instead of `eslint` commands in package scripts.
 
-### Pre-push Verification
-**CRITICAL**: This project uses an automated pre-push hook that runs verification checks before allowing pushes. The hook automatically executes:
+### Git Hooks with Lefthook
+**CRITICAL**: This project uses [Lefthook](https://github.com/evilmartians/lefthook) to manage git hooks and ensure consistent pre-push verification across all team members. The pre-push hook automatically executes:
 
-1. **Lint Check**: `pnpm lint` - All linting rules must pass
+1. **Lint & Format Check**: `pnpm lint:fix && pnpm typecheck` - All linting rules must pass and types must be valid
 2. **Build Check**: `pnpm build` - All packages must compile successfully  
 3. **Test Check**: `pnpm test` - All tests must pass
 
-**Automated Hook**: The pre-push hook is available in `scripts/pre-push` and can be installed by running:
+**Automatic Installation**: Lefthook hooks are automatically installed when you run `pnpm install` (via `postinstall` script). 
+
+**Manual Hook Management:**
 ```bash
-./scripts/setup-hooks.sh
+# Install hooks manually
+pnpm hooks:install
+
+# Uninstall hooks
+pnpm hooks:uninstall
+
+# Reinstall hooks (if needed)
+pnpm lefthook install
 ```
 
-Once installed, the hook will automatically run these checks when you attempt to push. If any check fails, the push will be rejected.
+**Hook Configuration**: The git hooks are configured in `lefthook.yml` at the project root. This ensures all team members share the same git hooks automatically.
 
 **Manual Verification Workflow:**
 ```bash
 # Run all verification steps manually (same as the hook)
-pnpm lint    # Fix any linting issues
+pnpm lint:fix && pnpm typecheck  # Fix any linting issues and check types
 pnpm build   # Ensure code compiles
 pnpm test    # Verify all tests pass
 ```
 
-**IMPORTANT**: The pre-push hook ensures code quality and prevents broken builds in the repository. If the hook prevents a push, fix the issues and try pushing again.
+**IMPORTANT**: The lefthook pre-push hook ensures code quality and prevents broken builds in the repository. If the hook prevents a push, fix the issues and try pushing again.
 
 ### Coding Style and Paradigms
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,27 @@
+# Lefthook configuration for Amazon Ebook Scraper
+# This ensures all team members share the same git hooks
+
+pre-push:
+  parallel: false
+  commands:
+    lint-and-format:
+      glob: "**/*.{ts,js,json}"
+      run: pnpm lint:fix && pnpm typecheck
+      stage_fixed: true
+    build:
+      run: pnpm build
+    test:
+      run: pnpm test
+
+# Optional: pre-commit hook for quick checks
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      glob: "**/*.{ts,js,json}"
+      run: pnpm lint:fix {staged_files}
+      stage_fixed: true
+
+# Install lefthook for new team members
+# Run: pnpm lefthook install
+install_command: pnpm lefthook install

--- a/package.json
+++ b/package.json
@@ -20,15 +20,25 @@
     "clean": "pnpm -r run clean",
     "install:all": "pnpm install",
     "update:all": "pnpm update",
+    "hooks:install": "lefthook install",
+    "hooks:uninstall": "lefthook uninstall",
     "pre-commit": "pnpm lint:fix && pnpm typecheck",
-    "pre-push": "pnpm pre-commit && pnpm build && pnpm test"
+    "pre-push": "pnpm pre-commit && pnpm build && pnpm test",
+    "postinstall": "lefthook install"
   },
   "engines": {
     "node": ">=22.0.0",
     "pnpm": ">=8.0.0"
   },
-  "keywords": ["amazon", "ebook", "scraper", "monorepo", "pnpm"],
+  "keywords": [
+    "amazon",
+    "ebook",
+    "scraper",
+    "monorepo",
+    "pnpm"
+  ],
   "devDependencies": {
-    "@biomejs/biome": "^1.9.4"
+    "@biomejs/biome": "^1.9.4",
+    "lefthook": "^1.12.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      lefthook:
+        specifier: ^1.12.2
+        version: 1.12.2
 
   apps/scraper-notifier:
     dependencies:
@@ -880,6 +883,60 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  lefthook-darwin-arm64@1.12.2:
+    resolution: {integrity: sha512-fTxeI9tEskrHjc3QyEO+AG7impBXY2Ed8V5aiRc3fw9POfYtVh9b5jRx90fjk2+ld5hf+Z1DsyyLq/vOHDFskQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.12.2:
+    resolution: {integrity: sha512-T1dCDKAAfdHgYZ8qtrS02SJSHoR52RFcrGArFNll9Mu4ZSV19Sp8BO+kTwDUOcLYdcPGNaqOp9PkRBQGZWQC7g==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.12.2:
+    resolution: {integrity: sha512-2n9z7Q4BKeMBoB9cuEdv0UBQH82Z4GgBQpCrfjCtyzpDnYQwrH8Tkrlnlko4qPh9MM6nLLGIYMKsA5nltzo8Cg==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.12.2:
+    resolution: {integrity: sha512-1hNY/irY+/3kjRzKoJYxG+m3BYI8QxopJUK1PQnknGo1Wy5u302SdX+tR7pnpz6JM5chrNw4ozSbKKOvdZ5VEw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.12.2:
+    resolution: {integrity: sha512-1W4swYIVRkxq/LFTuuK4oVpd6NtTKY4E3VY2Uq2JDkIOJV46+8qGBF+C/QA9K3O9chLffgN7c+i+NhIuGiZ/Vw==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.12.2:
+    resolution: {integrity: sha512-J6VGuMfhq5iCsg1Pv7xULbuXC63gP5LaikT0PhkyBNMi3HQneZFDJ8k/sp0Ue9HkQv6QfWIo3/FgB9gz38MCFw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.12.2:
+    resolution: {integrity: sha512-wncDRW3ml24DaOyH22KINumjvCohswbQqbxyH2GORRCykSnE859cTjOrRIchTKBIARF7PSeGPUtS7EK0+oDbaw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.12.2:
+    resolution: {integrity: sha512-2jDOkCHNnc/oK/vR62hAf3vZb1EQ6Md2GjIlgZ/V7A3ztOsM8QZ5IxwYN3D1UOIR5ZnwMBy7PtmTJC/HJrig5w==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.12.2:
+    resolution: {integrity: sha512-ZMH/q6UNSidhHEG/1QoqIl1n4yPTBWuVmKx5bONtKHicoz4QCQ+QEiNjKsG5OO4C62nfyHGThmweCzZVUQECJw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.12.2:
+    resolution: {integrity: sha512-TqT2jIPcTQ9uwaw+v+DTmvnUHM/p7bbsSrPoPX+fRXSGLzFjyiY+12C9dObSwfCQq6rT70xqQJ9AmftJQsa5/Q==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.12.2:
+    resolution: {integrity: sha512-2CeTu5NcmoT9YnqsHTq/TF36MlqlzHzhivGx3DrXHwcff4TdvrkIwUTA56huM3Nlo5ODAF/0hlPzaKLmNHCBnQ==}
+    hasBin: true
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1985,6 +2042,49 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  lefthook-darwin-arm64@1.12.2:
+    optional: true
+
+  lefthook-darwin-x64@1.12.2:
+    optional: true
+
+  lefthook-freebsd-arm64@1.12.2:
+    optional: true
+
+  lefthook-freebsd-x64@1.12.2:
+    optional: true
+
+  lefthook-linux-arm64@1.12.2:
+    optional: true
+
+  lefthook-linux-x64@1.12.2:
+    optional: true
+
+  lefthook-openbsd-arm64@1.12.2:
+    optional: true
+
+  lefthook-openbsd-x64@1.12.2:
+    optional: true
+
+  lefthook-windows-arm64@1.12.2:
+    optional: true
+
+  lefthook-windows-x64@1.12.2:
+    optional: true
+
+  lefthook@1.12.2:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.12.2
+      lefthook-darwin-x64: 1.12.2
+      lefthook-freebsd-arm64: 1.12.2
+      lefthook-freebsd-x64: 1.12.2
+      lefthook-linux-arm64: 1.12.2
+      lefthook-linux-x64: 1.12.2
+      lefthook-openbsd-arm64: 1.12.2
+      lefthook-openbsd-x64: 1.12.2
+      lefthook-windows-arm64: 1.12.2
+      lefthook-windows-x64: 1.12.2
 
   lilconfig@3.1.3: {}
 


### PR DESCRIPTION
Replace manual pre-push hook setup with lefthook to ensure all team members automatically share the same git hooks. This provides consistent code quality verification across the team.

## Changes
- Add lefthook dependency and configuration
- Configure pre-push hook with lint, build, and test checks
- Add automatic hook installation via postinstall script
- Update CLAUDE.md documentation with new setup instructions
- Maintain existing verification workflow (lint:fix, typecheck, build, test)

Resolves: #26

Generated with [Claude Code](https://claude.ai/code)